### PR TITLE
remove unnecessary character space before the language parameter

### DIFF
--- a/R/get_googlemap.R
+++ b/R/get_googlemap.R
@@ -202,7 +202,7 @@ get_googlemap <- function(
   scale_url <- if(!missing(scale)){ paste('scale=', scale) } else { '' }
   format_url <- if(!missing(format) && format != 'png8'){ paste('format=', format) } else { '' }
   maptype_url <- paste('maptype=', maptype, sep = '')
-  language_url <- if(!missing(language)){ paste('language=', language) } else { '' }  
+  language_url <- if(!missing(language)){ paste('language=', language, sep = '') } else { '' }  
   region_url <- if(!missing(region)){ paste('region=', region) } else { '' }
   
   markers_url <- 


### PR DESCRIPTION
In get_googlemap.R, a extra space (%20) followed some symbols “=” in addition to “language=%20zh-CN” in formatted url. 
For some reason, Google Map API is particularly sensitive to the extra space in parameter “language”. So the language parameter dose not work properly in ggmap package.
