### PR TITLE
Update get_map.Rd

### DIFF
--- a/man/get_map.Rd
+++ b/man/get_map.Rd
@@ -57,7 +57,8 @@ get_map(location = c(lon = -95.3632715, lat = 29.7632836), zoom = "auto",
   \item{api_key}{an api key for cloudmade maps}
 }
 \value{
-a data.frame with columns latitude, longitude, and fill
+an object of class "raster", plottable by the rasterLayer and 
+grid.raster functions
 }
 \description{
 get_map is a smart function which queries the Google Maps,


### PR DESCRIPTION
The get_map man page reports that get_map returns a data.frame (with columns latitude, longitude, and fill), whereas it seems to return an object of class "raster". (You'll likely want to change the wording of my proposed edit to the man page's "Value" section.)
