### PR TITLE
Create ggmapFileDrawer if not found.

### DIFF
--- a/R/get_googlemap.R
+++ b/R/get_googlemap.R
@@ -288,6 +288,9 @@ get_googlemap <- function(
   }
 
   # download and read in file
+  if(!file_drawer_found()) {
+    make_file_drawer()
+  }
   download.file(url, destfile = paste0("ggmapFileDrawer/", destfile), quiet = !messaging, mode = "wb")
   message(paste0("Map from URL : ", url))
   


### PR DESCRIPTION
Simple addition of a few lines to address #35.

Hi dkahle.  I am so impressed with the ggmap package.  I have all sorts of uses for it.

I had some issues with the CRAN version and png files not being found, so I `devtools::github_installed` your github version.

In that version I had some issues with the ggmapFileDrawer not being found.  That same issue was found in #35, so I added a few lines to resolve that.

Cheers,

eric
