### PR TITLE
Force query in geocode() when new parameters 

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -206,7 +206,7 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
 
 
     # temporarily save it
-    storeGeocodedInformation(loc, gc)
+    storeGeocodedInformation(posturl, gc)
 
   }
 

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -206,7 +206,7 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
 
 
     # temporarily save it
-    storeGeocodedInformation(posturl, gc)
+    storeGeocodedInformation(url_string, gc)
 
   }
 


### PR DESCRIPTION
Currently, successive calls to `geocode()` using identical  values for the `location` parameter do not trigger a new query but instead return the results cached in the hidden global `.GeocodedInformation`.  This is typically desirable unless one wishes to run a new query using the same `location` but alternative values for the `client`, `signature`, or `source` parameters.  It's especially problematic when one wants to re-geocode a location using the dsk API when the Google API results have already been cached (or vice versa), as the results are almost never identical for elements such as the lat and longs.

My workaround has been to `rm(.GeocodedInformation)` to force a new query but an easy solution to this would be to just pass the query sting as the name instead of the location string.

Did you intend for `.GeocodenInformation` to persist in between calls to `geocode()`?  I see a `clearGeocodedInformation()` defined [here](https://github.com/dkahle/ggmap/blob/master/R/geocode.R#L446-L454) but it is not called anywhere that I could find.