### PR TITLE
mutate_geocode() is incompatible with the behavior of tbl_df-type data frames

### DIFF
--- a/R/mutate_geocode.R
+++ b/R/mutate_geocode.R
@@ -28,7 +28,7 @@
 #' }
 #'
 mutate_geocode <- function(data, location, ...){
-  locs <- data[, deparse(substitute(location)), drop = TRUE]
+  locs <- data[[deparse(substitute(location))]]
   gcdf <- geocode(locs, ...)
   data.frame(data, gcdf)
 }


### PR DESCRIPTION
If the data frame that is passed into `mutate_geocode()` happens to be a class of `tbl_df` (via [dplyr](https://github.com/hadley/dplyr/), an error will arise due to `tbl_df`'s different subsetting behavior.
- The issue is described here: [Problem with table_df](https://github.com/hadley/dplyr/issues/587)
- At this point, [Hadley believes that tbl_df does not need to change](https://github.com/hadley/dplyr/issues/1345).
##### Demonstration of error:

``` R
library(ggmap)
df <- data.frame(
  address = c("1600 Pennsylvania Avenue, Washington DC", "", "houston texas"),
  stringsAsFactors = FALSE
)
## Convert to tbl_df
tdf <- as_data_frame(df)
mutate_geocode(tdf, location = address, source = "google")
```
###### Error message:

```
  Error: is.character(location) is not TRUE
  In addition: Warning message:
  drop ignored 
```

I'm not sure of how often ggmap users will have a situation in which their data frames are actually tbl_dfs...all I know is that it happened to me on my very first spin of mutate_geocode :).

In the pull request I've made what I think fixes the issue without requiring the user to convert their tbl_df before running `mutate_geocode()`. I'm not sure if this works for all cases or introduces any other kind of breakage. Or if any of ggmap's other vector functions might need the same fix.

`mutate_geocode()` coerces the result into a data.frame...not sure if that should be changed in case a user is expecting tbl_df() back...
