### PR TITLE
Support non-ASCII characters in origin and destination

### DIFF
--- a/R/route.R
+++ b/R/route.R
@@ -74,10 +74,10 @@ route <- function(from, to, mode = c("driving","walking","bicycling", "transit")
 
   # format url
   origin <- from
-  origin <- gsub(" ", "+", origin)
+  origin <- utils::URLencode(origin)
   origin <- paste("origin=", origin, sep = "")
   destination <- to
-  destination <- gsub(" ", "+", destination)
+  destination <- utils::URLencode(destination)
   destination <- paste("destination=", destination, sep = "")
   mode4url <- paste("mode=", mode, sep = "")
   unit4url <- paste("units=", "metric", sep = "")


### PR DESCRIPTION
use URLencode()

This might break existing scripts that worked around this issue by calling URLencode() themselves on the input.

This patch applies to the CRAN version (?) to support compatibility with the "old" ggplot2 package. If I add a NEWS bullet, the patch cannot be applied anymore.