### PR TITLE
Update gglocator.R

### DIFF
--- a/R/gglocator.R
+++ b/R/gglocator.R
@@ -53,8 +53,10 @@ gglocator <- function(n = 1, message = FALSE,
 
   # scale the position to the plot
   object <- last_plot()
-  xrng <- with(object, range(data[,deparse(mapping$x)]))
-  yrng <- with(object, range(data[,deparse(mapping$y)]))
+  # get the x.range and y.range from ggplot
+  plot_info <- ggplot_build(object)
+  xrng <- plot_info$panel$ranges[[1]]$x.range
+  yrng <- plot_info$panel$ranges[[1]]$y.range
 
   xrng <- expand_range(range = xrng, mul = xexpand[1], add = xexpand[2])
   yrng <- expand_range(range = yrng, mul = yexpand[1], add = yexpand[2])


### PR DESCRIPTION
Getting the x/y range from the data did not work when the limits were changed or the data was added to a plot object such as geom_line and not directly into ggplot. 

Getting it via ggplot_build is robust against changing x/ylim or putting data into plot objects.

What will not work are windows with multiple plots, but this did not work before either.