### PR TITLE
Update gglocator.R

### DIFF
--- a/R/gglocator.R
+++ b/R/gglocator.R
@@ -36,7 +36,7 @@
 #'
 #'
 gglocator <- function(n = 1, message = FALSE,
-  xexpand = c(.05, 0), yexpand = c(.05, 0)
+  xexpand = c(.0, 0), yexpand = c(.0, 0)
 ){
 
   if(n > 1){


### PR DESCRIPTION
Fix for default expand. 
ggplot seems to scale the plot range by default with 0.05% in all directions. The default expand as done previously used to compensate this by setting the scaling to 0.05, because it got the range from the plot data. 
Getting the coordinates from ggplot_build this scaling is no longer necessary, because ggplot_build gives already the range scaled for the plot.

I missed this in the initial commit, because I was only testing for large values, where this does not weight in as much.