### PR TITLE
fixes #84.  The `base_layer` needed to be evaluated in the environment

### DIFF
--- a/R/ggmap.R
+++ b/R/ggmap.R
@@ -536,7 +536,12 @@ ggmap <- function(ggmap, extent = "panel", base_layer, maprange = FALSE,
       sep = " + "
     )
 
-    p <- eval(parse(text = str2parse))
+    # attempt to ensure that base_layer argument is evaluated correctly by forcing evaluation in the calling environment.
+    # if that fails, the previous default behavior is provided. see https://github.com/dkahle/ggmap/issues/84 for background.
+    p <- try(eval(parse(text = paste(base,collapse="")),parent.frame(1))+geom_blank()+inset_raster(ggmap, xmin, xmax, ymin, ymax))
+    if(inherits(p,"try-error"))
+      p <- eval(parse(text = str2parse))
+
     p <- p + annotate("rect", xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax,
   	  fill = darken[2], alpha = as.numeric(darken[1]))
   }


### PR DESCRIPTION
... from which it was called. However, `geom_blank()+insert_raster...` should be evaluated in the current environment.  This patch attempts to create that behavior and if that throws an error, it reverts to the previous behavior.

This one actually is for #84.