### PR TITLE
Allow for Google maps API Key in ggmap::geocode

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -81,7 +81,7 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
     source = c("google", "dsk"), messaging = FALSE,
     force = ifelse(source == "dsk", FALSE, TRUE), sensor = FALSE,
     override_limit = FALSE,
-    client = "", signature = "", nameType = c("long", "short"), data
+    client = "", signature = "", key = "", nameType = c("long", "short"), data
 ){
 
   # basic parameter check
@@ -101,6 +101,8 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
     stop("if signature argument is specified, client must be as well.", call. = FALSE)
   } else if(client != "" && signature == ""){
     stop("if client argument is specified, signature must be as well.", call. = FALSE)
+  } else if (client == "" && signature == "" && key != "") {
+    userType <- "business"
   } else {
     userType <- "free"
   }
@@ -166,6 +168,7 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
   sensor4url <- paste("sensor=", tolower(as.character(sensor)), sep = "")
   client4url <- paste("client=", client, sep = "")
   signature4url <- paste("signature=", signature, sep = "")
+  key4url <- paste("key=", key, sep = "")
   location4url <- chartr(" ", "+", location)
   posturl <- paste(location, sensor4url, sep = "&")
   if(userType == "business") posturl <- paste(posturl, client4url, signature4url, sep = "&")

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -171,10 +171,11 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
   key4url <- paste("key=", key, sep = "")
   location4url <- chartr(" ", "+", location)
   posturl <- paste(location, sensor4url, sep = "&")
-  if(userType == "business") posturl <- paste(posturl, client4url, signature4url, sep = "&")
+  if(userType == "business") posturl <- paste(posturl, ifelse(key == "",paste(client4url, signature4url, sep = '&'), key4url),
+                     sep = "&")
 
   if(source == "google"){
-    url_string <- paste("http://maps.googleapis.com/maps/api/geocode/json?address=", posturl, sep = "")
+    url_string <- paste("https://maps.googleapis.com/maps/api/geocode/json?address=", posturl, sep = "")
   } else if(source == "dsk"){
     url_string <- paste("http://www.datasciencetoolkit.org/maps/api/geocode/json?address=", posturl, sep = "")
   }


### PR DESCRIPTION
ggmap::geocode does not recognize a Google maps API key to convert the account type to 'business'.  I've used these changes to pull lat-long information for 15000+ queries without bumping into the 2500 query limit I had experienced without the API key.   
