### PR TITLE
Bug fix: remove file from the drawer, not from the working directory

### DIFF
--- a/R/file_drawer.R
+++ b/R/file_drawer.R
@@ -56,7 +56,7 @@ file_drawer_set <- function(url, map, name = NULL) {
   index <- file_drawer_index()
 
   if (url %in% names(index)) {
-    file.remove(index[[url]])
+    file.remove(file_drawer(index[[url]]))
   }
   index[[url]] <- name
   saveRDS(index, file_drawer("index.rds"))


### PR DESCRIPTION
This fixes a bug that I noticed when running `get_map()`, where I got warning messages about trying to remove non-existent files.