### PR TITLE
Suggesting move to ggplot2 >= 2.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ BugReports: https://github.com/dkahle/ggmap/issues
 Authors@R: c(person("David", "Kahle", email = "david.kahle@gmail.com", role = c("aut", "cre")),
   person("Hadley", "Wickham", email = "h.wickham@gmail.com", role = "aut"))
 Depends:
-    R (>= 2.14.0),
-    ggplot2 (>= 2.0.0)
+    R (>= 3.1.0),
+    ggplot2 (>= 2.2.0)
 Imports:
     proto,
     RgoogleMaps,

--- a/R/ggmap.R
+++ b/R/ggmap.R
@@ -244,7 +244,7 @@
 #'
 #' # 2d histogram...
 #' HoustonMap +
-#'   stat_bin2d(aes(x = lon, y = lat, colour = offense, fill = offense),
+#'   stat_bin_2d(aes(x = lon, y = lat, colour = offense, fill = offense),
 #'     size = .5, bins = 30, alpha = 2/4, data = violent_crimes) +
 #'    scale_colour_discrete("Offense",
 #'      labels = c("Robery","Aggravated Assault","Rape","Murder"),

--- a/R/theme_inset.R
+++ b/R/theme_inset.R
@@ -37,17 +37,12 @@
 #' }
 #'
 theme_inset <- function (base_size = 12){
-  t <- theme_get()
-  t$axis.line <- element_blank()
-  t$axis.text.x <- element_blank()
-  t$axis.text.y <- element_blank()
-  t$axis.ticks <- element_blank()
-  t$axis.title.x <- element_blank()
-  t$axis.title.y <- element_blank()
-  t$axis.ticks.length <- unit(0, "lines")
-  t$axis.ticks.margin <- unit(0, "lines")
-  t$panel.margin <- unit(0, "lines")
-  t$plot.margin <- unit(c(0, 0, 0, 0), "lines")
-  t$legend.position <- 'none'
-  t
+  theme(axis.line         = element_blank(),
+        axis.text         = element_blank(),
+        axis.ticks        = element_blank(),
+        axis.title        = element_blank(),
+        axis.ticks.length = unit(0, "lines"),
+        panel.spacing     = unit(0, "lines"),
+        plot.margin       = unit(c(0, 0, 0, 0), "lines"),
+        legend.position   = 'none')
 }

--- a/R/theme_nothing.R
+++ b/R/theme_nothing.R
@@ -49,7 +49,7 @@ theme_nothing <- function(base_size = 12, legend = FALSE){
      panel.grid.major =   element_blank(),
      panel.grid.minor =   element_blank(),
      axis.ticks.length =  unit(0, "cm"),
-     panel.margin =       unit(0, "lines"),
+     panel.spacing =      unit(0, "lines"),
      plot.margin =        unit(c(0, 0, 0, 0), "lines"),
      complete = TRUE
    ))
@@ -60,7 +60,7 @@ theme_nothing <- function(base_size = 12, legend = FALSE){
      text =               element_blank(),
      axis.ticks.length =  unit(0, "cm"),
      legend.position =    "none",
-     panel.margin =       unit(0, "lines"),
+     panel.spacing =      unit(0, "lines"),
      plot.margin =        unit(c(0, 0, 0, 0), "lines"),
      complete = TRUE
    ))

--- a/man/ggmap.Rd
+++ b/man/ggmap.Rd
@@ -263,7 +263,7 @@ HoustonMap +
 
 # 2d histogram...
 HoustonMap +
-  stat_bin2d(aes(x = lon, y = lat, colour = offense, fill = offense),
+  stat_bin_2d(aes(x = lon, y = lat, colour = offense, fill = offense),
     size = .5, bins = 30, alpha = 2/4, data = violent_crimes) +
    scale_colour_discrete("Offense",
      labels = c("Robery","Aggravated Assault","Rape","Murder"),


### PR DESCRIPTION
The latest ggplot2 release nags about using the `panel.margin` theme option. One way to stop the warnings is to start using the ggplot2 >= 2.2.0 equivalent `panel.spacing`. The ggplot2 update implies requiring R >= 3.1.0.

Also `stat_bin_2d()` instead of `stat_bin2d()` in an example (independent of ggplot2 version bump), and what I think is a cleaner way to implement `theme_inset()`.