### PR TITLE
Scale y axis of gglocator()

### DIFF
--- a/man/gglocator.Rd
+++ b/man/gglocator.Rd
@@ -4,7 +4,8 @@
 \alias{gglocator}
 \title{Locator for ggplots.}
 \usage{
-gglocator(n = 1, message = FALSE, xexpand = c(0, 0), yexpand = c(0, 0))
+gglocator(n = 1, message = FALSE, xexpand = c(0, 0), yexpand = c(0, 0),
+  mercator = TRUE)
 }
 \arguments{
 \item{n}{number of points to locate.}
@@ -14,6 +15,10 @@ gglocator(n = 1, message = FALSE, xexpand = c(0, 0), yexpand = c(0, 0))
 \item{xexpand}{expand argument in scale_x_continuous}
 
 \item{yexpand}{expand argument in scale_y_continuous}
+
+\item{mercator}{logical flag; should the plot be treated as using
+the projection common to most web map services? Set to FALSE if
+the axes on the plot use a linear scale.}
 }
 \value{
 a data frame with columns according to the x and y
@@ -33,7 +38,7 @@ p <- qplot(x, y, data = df) +
   annotate(geom = "point", x = -2, y = -2, colour = "red")
 print(p)
 cat("click red point\\n")
-print(pt <- gglocator())
+print(pt <- gglocator(mercator = FALSE))
 p2 <- last_plot() +
   annotate("point", pt$x, pt$y, color = "blue", size = 3, alpha = .5)
 cat("a blue point should appear where you clicked\\n")
@@ -44,7 +49,8 @@ p3 <- p +
   scale_y_continuous(expand = c(0,0))
 print(p3)
 cat("click any point\\n")
-print(gglocator(1, xexpand = c(0,0), yexpand = c(0,0)))
+print(gglocator(1, xexpand = c(0,0), yexpand = c(0,0),
+                mercator = FALSE))
 
 
 }


### PR DESCRIPTION
I think `gglocator()` should take into account the map projection used in web maps instead of treating the y axis as having a linear scale. Assuming that `LonLat2XY()` and `XY2LonLat()` work properly and that the y axis uses the correct scale, I think this patch should work. The function now has a new argument, `"mercator"` with a default of `TRUE`. Feel free to rename it.

Here are some example screenshots obtained with the following code and trying to click accurately. Blue points are the new results (`mercator = TRUE`) and red points depict the previous behavior of `gglocator()`, now with `mercator = FALSE`.

```
library(ggmap)

## Aasiaat is a town in Greenland
aasiaat <- get_googlemap("Aasiaat", zoom = 4)
for (ext in c("panel", "normal")) {
    ggmap(aasiaat, extent = ext)

    ## For points and points2, try hitting the latitudes 60, 65, 70 and 75
    points <- gglocator(4)
    points2 <- gglocator(4, mercator=FALSE)

    last_plot() +
        geom_point(aes(x = lon, y = lat, colour = projection),
                   data = cbind(rbind(points, points2),
                                data.frame(projection=c(rep("mercator", 4),
                                                        rep("linear", 4)))))
}

## South America
southam <- get_googlemap("Comodoro Rivadavia", zoom = 5)
ggmap(southam, extent = "device")

## Try hitting "Concepción", "Comodoro Rivadavia", "El Calafate" and
## "Rio Grande", the circles pointing at the cities.
points3 <- gglocator(4)
points4 <- gglocator(4, mercator=FALSE)
last_plot() +
    geom_point(aes(x = lon, y = lat, colour = projection),
               data = cbind(rbind(points3, points4),
                            data.frame(projection=c(rep("mercator", 4),
                                                    rep("linear", 4)))))

```

![gglocator](https://cloud.githubusercontent.com/assets/2980656/20456396/83c69542-ae7e-11e6-8689-997e0111a3ca.png)
![gglocator2](https://cloud.githubusercontent.com/assets/2980656/20456394/83c60ad2-ae7e-11e6-9cde-2489d4508796.png)
![gglocator3](https://cloud.githubusercontent.com/assets/2980656/20456395/83c66cac-ae7e-11e6-9899-2571eb163c91.png)
