### PR TITLE
Simple fixes to mapdist()

### DIFF
--- a/R/mapdist.R
+++ b/R/mapdist.R
@@ -151,7 +151,7 @@ mapdist <- function(from, to, mode = c("driving","walking","bicycling","transit"
     tree$rows[[c(1,1)]]
   }
 
-  out <- dlply(from_to_df, "from", getdists)
+  out <- dlply(unique(from_to_df), "from", getdists)
 
   # return all
   if(output == "all") return(out)

--- a/R/mapdist.R
+++ b/R/mapdist.R
@@ -79,7 +79,8 @@ mapdist <- function(from, to, mode = c("driving","walking","bicycling","transit"
 
   	# format basic url
     origins <- URLencode(df$from[1], reserved = TRUE)
-    destinations <- URLencode(df$to, reserved = TRUE)
+    destinations <- vapply(df$to, URLencode, "", reserved = TRUE,
+                           USE.NAMES = FALSE)
     posturl <- paste(
       fmteq(origins), fmteq(destinations, paste, collapse = "|"),
       fmteq(mode), fmteq(language),


### PR DESCRIPTION
These are simple fixes to `mapdist()`, for example fixing issue #70.

I am aware that a set of more advanced updates is proposed in pull request #129, and this pull request does not play well with that. However, is it desirable to change the semantics of vector origins and destinations so that all pairs of origin-destination (`from`-`to`) are searched, as happens in #129? At present, with `from=c("A", "B")` and `to=c("C", "D")`, only routes `A`-`C` and `B`-`D` are searched, but #129 also searches `A`-`D` and `B`-`C`.