### PR TITLE
Restructuring of examples: some \donttest where previously \dontrun

### DIFF
--- a/R/LonLat2XY.R
+++ b/R/LonLat2XY.R
@@ -17,6 +17,7 @@
 #' @export
 #' @examples
 #'
+#' LonLat2XY(13, 60, 4)
 #'
 #' \dontrun{
 #' gc <- geocode('baylor university')

--- a/R/LonLat2XY.R
+++ b/R/LonLat2XY.R
@@ -19,7 +19,7 @@
 #'
 #' LonLat2XY(13, 60, 4)
 #'
-#' \dontrun{
+#' \donttest{
 #' gc <- geocode('baylor university')
 #' LonLat2XY(gc$lon, gc$lat, 10)
 #'

--- a/R/XY2LonLat.R
+++ b/R/XY2LonLat.R
@@ -22,7 +22,6 @@
 #' XY2LonLat(480, 845, zoom = 11)
 #' XY2LonLat(0, 0, zoom = 1)
 #' XY2LonLat(0, 0, 255, 255, zoom = 1)
-#' XY2LonLat(0, 0, 255, 255, zoom = 1)
 #'
 XY2LonLat <- function(X, Y, zoom, x = 0, y = 0, xpix=255, ypix=255){
   n <- 2^zoom

--- a/R/XY2LonLat.R
+++ b/R/XY2LonLat.R
@@ -19,14 +19,10 @@
 #' @export
 #' @examples
 #'
-#'
-#' \dontrun{
 #' XY2LonLat(480, 845, zoom = 11)
 #' XY2LonLat(0, 0, zoom = 1)
 #' XY2LonLat(0, 0, 255, 255, zoom = 1)
 #' XY2LonLat(0, 0, 255, 255, zoom = 1)
-#'
-#' }
 #'
 XY2LonLat <- function(X, Y, zoom, x = 0, y = 0, xpix=255, ypix=255){
   n <- 2^zoom

--- a/R/bb2bbox.R
+++ b/R/bb2bbox.R
@@ -13,7 +13,7 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{# cut down on R CMD check time
+#' \donttest{# cut down on R CMD check time
 #'
 #' # grab a center/zoom map and compute its bounding box
 #' gc <- geocode("white house, washington dc")

--- a/R/file_drawer.R
+++ b/R/file_drawer.R
@@ -11,10 +11,10 @@
 #' @keywords internal
 #' @examples
 #'
-#' \dontrun{# if server is unresponsive, R check will fail
-#'
 #' file_drawer()
 #' dir(file_drawer())
+#'
+#' \dontrun{# if server is unresponsive, R check will fail
 #'
 #' # The first time you run this, the tiles are downloaded from the server
 #' map <- get_stamenmap()

--- a/R/file_drawer.R
+++ b/R/file_drawer.R
@@ -14,7 +14,7 @@
 #' file_drawer()
 #' dir(file_drawer())
 #'
-#' \dontrun{# if server is unresponsive, R check will fail
+#' \donttest{# if server is unresponsive, R check will fail
 #'
 #' # The first time you run this, the tiles are downloaded from the server
 #' map <- get_stamenmap()

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -42,7 +42,7 @@
 #'
 #' geocode("ninos", inject = "region=es", urlonly = TRUE)
 #'
-#' \dontrun{ # Server response can be slow; this cuts down check time.
+#' \donttest{ # Server response can be slow; this cuts down check time.
 #' geocode("houston texas")
 #' geocode("1600 pennsylvania avenue, washington dc")
 #' geocode("the white house")
@@ -58,21 +58,21 @@
 #' geocode("houston texas", output = "more")
 #' geocode("Baylor University", output = "more")
 #' str(geocode("Baylor University", output = "all"))
+#' }
 #'
-#'
+#' \dontrun{
 #' ##### interfacing with the google geocoding api
 #' ########################################
 #'
 #' register_google(key = "your code here")
 #' geocode("houston texas")
+#' }
 #'
-#'
+#' \donttest{
 #' # see how many requests we have left with google
 #' geocodeQueryCheck()
 #' geocode("one bear place, waco, texas")
 #' geocode("houston texas", force = TRUE)
-#'
-#'
 #'
 #' ##### known issues
 #' ########################################

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -37,17 +37,17 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{ # Server response can be slow; this cuts down check time.
-#'
 #' ##### basic usage
 #' ########################################
 #'
+#' geocode("ninos", inject = "region=es", urlonly = TRUE)
+#'
+#' \dontrun{ # Server response can be slow; this cuts down check time.
 #' geocode("houston texas")
 #' geocode("1600 pennsylvania avenue, washington dc")
 #' geocode("the white house")
 #' geocode(c("the white house", "washington dc"))
 #' # see also mutate_geocode()
-#' geocode("ninos", inject = "region=es", urlonly = TRUE)
 #'
 #'
 #' ##### types of output

--- a/R/geom_leg.R
+++ b/R/geom_leg.R
@@ -12,7 +12,7 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{ # removed for R CMD check speed
+#' \donttest{ # removed for R CMD check speed
 #'
 #' map <- get_map(
 #'   location = c(-77.0425, 38.8925), # painfully picked by hand

--- a/R/get_googlemap.R
+++ b/R/get_googlemap.R
@@ -73,7 +73,7 @@
 #'
 #' get_googlemap(urlonly = TRUE)
 #'
-#' \dontrun{ # to diminish run check time
+#' \donttest{ # to diminish run check time
 #' ggmap(get_googlemap())
 #'
 #'
@@ -99,13 +99,16 @@
 #' # (make your graphics device as large as possible)
 #' ggmap(get_googlemap(center, scale = 1), extent = "panel") # pixelated
 #' ggmap(get_googlemap(center, scale = 2), extent = "panel") # fine
+#' }
 #'
+#' \dontrun{
 #' # archiving; note that you must meet google's terms for this condition
 #' map <- get_googlemap(archiving = TRUE)
 #' map <- get_googlemap()
 #' ggmap(map)
+#' }
 #'
-#'
+#' \donttest{
 #' # style
 #' map <- get_googlemap(
 #'   maptype = "roadmap",
@@ -113,10 +116,6 @@
 #'   color = "bw"
 #' )
 #' ggmap(map)
-#'
-#'
-#'
-#'
 #' }
 #'
 get_googlemap <- function(

--- a/R/get_googlemap.R
+++ b/R/get_googlemap.R
@@ -71,10 +71,9 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{ # to diminish run check time
-#'
-#'
 #' get_googlemap(urlonly = TRUE)
+#'
+#' \dontrun{ # to diminish run check time
 #' ggmap(get_googlemap())
 #'
 #'

--- a/R/get_map.R
+++ b/R/get_map.R
@@ -44,12 +44,18 @@
 #' str(map)
 #' ggmap(map)
 #'
-#' \dontrun{
+#' \donttest{
 #' # not run by check to reduce time; also,
 #' # osm may error due to server overload
 #'
 #' (map <- get_map(maptype = "roadmap"))
+#' }
+#'
+#' \dontrun{
 #' (map <- get_map(source = "osm"))
+#' }
+#'
+#' \donttest{
 #' (map <- get_map(source = "stamen", maptype = "watercolor"))
 #'
 #' map <- get_map(location = "texas", zoom = 6, source = "stamen")

--- a/R/get_map.R
+++ b/R/get_map.R
@@ -59,7 +59,7 @@
 #' (map <- get_map(source = "stamen", maptype = "watercolor"))
 #'
 #' map <- get_map(location = "texas", zoom = 6, source = "stamen")
-#' ggmap(map, fullpage = TRUE)
+#' ggmap(map, extent = "device")
 #'
 #' }
 get_map <- function(

--- a/R/get_navermap.R
+++ b/R/get_navermap.R
@@ -43,7 +43,7 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{
+#' \donttest{
 #' # not run to reduce R CMD check time
 #'
 #' map <- get_navermap(key="c75a09166a38196955adee04d3a51bf8", uri="www.r-project.org")

--- a/R/get_stamenmap.R
+++ b/R/get_stamenmap.R
@@ -30,6 +30,21 @@
 #'
 #' get_stamenmap(urlonly = TRUE)
 #'
+#' \donttest{
+#' # since mid-2016, stamen's terrain tileset is available for
+#' # the entire globe
+#' place <- "mount everest"
+#' (google <- get_googlemap(place, zoom = 9))
+#' ggmap(google)
+#' bbox_everest <- c(left = 86.05, bottom = 27.21, right = 87.81, top = 28.76)
+#' ggmap(get_stamenmap(bbox_everest, zoom = 9))
+#'
+#' # here's an interesting example:
+#' us <- c(left = -125, bottom = 25.75, right = -67, top = 49)
+#' map <- get_stamenmap(us, zoom = 5, maptype = "toner-labels")
+#' ggmap(map)
+#' }
+#'
 #' \dontrun{ # to diminish run check time
 #'
 #' ##### basic usage
@@ -48,16 +63,6 @@
 #' ggmap(get_stamenmap(bbox, zoom = 15))
 #' # ggmap(get_stamenmap(bbox, zoom = 16))
 #' # ggmap(get_stamenmap(bbox, zoom = 17))
-#'
-#'
-#'
-#' # since mid-2016, stamen's terrain tileset is available for
-#' # the entire globe
-#' place <- "mount everest"
-#' (google <- get_googlemap(place, zoom = 9))
-#' ggmap(google)
-#' bbox_everest <- c(left = 86.05, bottom = 27.21, right = 87.81, top = 28.76)
-#' ggmap(get_stamenmap(bbox_everest, zoom = 9))
 #'
 #'
 #' # note that the osm code may not run due to overloaded
@@ -110,13 +115,6 @@
 #'
 #' ggmap(get_stamenmap(bbox, zoom = 15, maptype = "toner"))+
 #'   geom_point(aes(x = lon, y = lat), data = gc, colour = "red", size = 2)
-#'
-#'
-#' # here's an interesting example:
-#' us <- c(left = -125, bottom = 25.75, right = -67, top = 49)
-#' map <- get_stamenmap(us, zoom = 5, maptype = "toner-labels")
-#' ggmap(map)
-#'
 #'
 #'
 #' # accuracy check - white house

--- a/R/get_stamenmap.R
+++ b/R/get_stamenmap.R
@@ -28,8 +28,9 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{ # to diminish run check time
+#' get_stamenmap(urlonly = TRUE)
 #'
+#' \dontrun{ # to diminish run check time
 #'
 #' ##### basic usage
 #' ########################################

--- a/R/ggimage.R
+++ b/R/ggimage.R
@@ -19,7 +19,7 @@
 #' ggimage(t(img[,4:1]), fullpage = FALSE)
 #'
 #'
-#' \dontrun{
+#' \donttest{
 #' # not run due to slow performance
 #'
 #' data(hadley)

--- a/R/ggmap.R
+++ b/R/ggmap.R
@@ -24,7 +24,7 @@
 #' @export ggmap inset inset_raster
 #' @examples
 #'
-#' \dontrun{## map queries drag R CMD check
+#' \donttest{## map queries drag R CMD check
 #'
 #'
 #' ## extents and legends

--- a/R/mapdist.R
+++ b/R/mapdist.R
@@ -28,6 +28,7 @@
 #' \url{http://code.google.com/apis/maps/documentation/distancematrix/}
 #' @export
 #' @examples
+#' mapdist("waco, texas", "houston, texas", urlonly = TRUE)
 #'
 #' \dontrun{# online queries draw R CMD check times
 #'
@@ -150,6 +151,7 @@ mapdist <- function(from, to, mode = c("driving","walking","bicycling","transit"
     tree$rows[[c(1,1)]]
   }
 
+  if(urlonly) return(daply(from_to_df, "from", getdists))
   out <- dlply(from_to_df, "from", getdists)
 
   # return all

--- a/R/mapdist.R
+++ b/R/mapdist.R
@@ -39,13 +39,17 @@
 #' mapdist(from, to)
 #' mapdist(from, to, mode = "bicycling")
 #' mapdist(from, to, mode = "walking")
+#' }
 #'
+#' \dontrun{
 #' # google requires a key for mode="transit"
 #' register_google(key = "[your key here]")
 #' from <- "city hall houston texas"
 #' to <- "nrg stadium houston texas"
 #' mapdist(from, to, mode = "transit")
+#' }
 #'
+#' \donttest{
 #' from <- c("houston", "houston", "dallas")
 #' to <- c("waco, texas", "san antonio", "houston")
 #' mapdist(from, to)

--- a/R/mapdist.R
+++ b/R/mapdist.R
@@ -155,8 +155,8 @@ mapdist <- function(from, to, mode = c("driving","walking","bicycling","transit"
     tree$rows[[c(1,1)]]
   }
 
-  if(urlonly) return(daply(from_to_df, "from", getdists))
-  out <- dlply(from_to_df, "from", getdists)
+  if(urlonly) return(daply(unique(from_to_df), "from", getdists))
+  out <- dlply(unique(from_to_df), "from", getdists)
 
   # return all
   if(output == "all") return(out)

--- a/R/mutate_geocode.R
+++ b/R/mutate_geocode.R
@@ -13,13 +13,12 @@
 #' @export
 #' @examples
 #'
-#'
+#' \dontrun{ # Server response can be slow; this cuts down check time.
 #' df <- data.frame(
 #'   address = c("1600 Pennsylvania Avenue, Washington DC", "", "houston texas"),
 #'   stringsAsFactors = FALSE
 #' )
 #'
-#' \dontrun{ # Server response can be slow; this cuts down check time.
 #' mutate_geocode(df, address)
 #'
 #'

--- a/R/mutate_geocode.R
+++ b/R/mutate_geocode.R
@@ -13,7 +13,7 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{ # Server response can be slow; this cuts down check time.
+#' \donttest{ # Server response can be slow; this cuts down check time.
 #' df <- data.frame(
 #'   address = c("1600 Pennsylvania Avenue, Washington DC", "", "houston texas"),
 #'   stringsAsFactors = FALSE

--- a/R/qmap.R
+++ b/R/qmap.R
@@ -12,14 +12,20 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{
+#' \donttest{
 #' # these examples have been excluded for checking efficiency
 #'
 #' location <- "marrs mclean science, waco, texas"
 #' qmap(location)
 #' qmap(location, zoom = 14)
+#' }
+#'
+#' \dontrun{
 #' qmap(location, zoom = 14, source = "osm")
 #' qmap(location, zoom = 14, source = "osm", scale = 20000)
+#' }
+#'
+#' \donttest{
 #' qmap(location, zoom = 14, maptype = "satellite")
 #' qmap(location, zoom = 14, maptype = "hybrid")
 #' qmap(location, zoom = 14, maptype = "toner", source = "stamen")

--- a/R/qmplot.R
+++ b/R/qmplot.R
@@ -117,9 +117,9 @@
 #'   scale_alpha("Wind Speed\nand\nDirection", range = c(.1, .75)) +
 #'   guides(fill = guide_legend(), alpha = guide_legend())
 #'
+#' } # end donttest
 #'
-#'
-#'
+#' \dontrun{
 #' ## kriging
 #' ############################################################
 #' # the below examples show kriging based on undeclared packages
@@ -128,9 +128,7 @@
 #' # they also require the rgdal library
 #'
 #'
-#' library(lattice)
-#' library(sp)
-#' library(rgdal)
+#' if (require("lattice") && require("sp") && require("rgdal")) {
 #'
 #' # load in and format the meuse dataset (see bivand, pebesma, and gomez-rubio)
 #' data(meuse)
@@ -159,10 +157,8 @@
 #'
 #'
 #'
-#'
-#'
+#' if (require("gstat")) { # still requiring lattice, sp and rgdal
 #' # load in the meuse.grid dataset (looking toward kriging)
-#' library(gstat)
 #' data(meuse.grid)
 #' coordinates(meuse.grid) <- c("x", "y")
 #' proj4string(meuse.grid) <- CRS("+init=epsg:28992")
@@ -252,13 +248,9 @@
 #'   ) +
 #'   scale +
 #'   scale_size("Observed\nLog Zinc")
+#' }} # end two cases of if (require ...)
 #'
-#'
-#'
-#'
-#'
-#'
-#' } # end donttest
+#' } # end dontrun
 #'
 qmplot <- function(x, y, ..., data, zoom, source = "stamen", maptype = "toner-lite",
   extent = "device", legend = "right", padding = .02, force = FALSE,

--- a/R/qmplot.R
+++ b/R/qmplot.R
@@ -45,7 +45,7 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{ # these are skipped to conserve R check time
+#' \donttest{ # these are skipped to conserve R check time
 #'
 #' qmplot(lon, lat, data = crime)
 #'
@@ -258,7 +258,7 @@
 #'
 #'
 #'
-#' } # end dontrun
+#' } # end donttest
 #'
 qmplot <- function(x, y, ..., data, zoom, source = "stamen", maptype = "toner-lite",
   extent = "device", legend = "right", padding = .02, force = FALSE,

--- a/R/register_google.R
+++ b/R/register_google.R
@@ -26,12 +26,10 @@
 #' goog_key()
 #' has_goog_client()
 #' has_goog_signature()
+#' \dontrun{
 #' register_google(key = "[your key here]")
+#' }
 #'
-
-
-
-
 #' @rdname register_google
 #' @export
 register_google <- function (key, account_type, client, signature, second_limit, day_limit) {

--- a/R/revgeocode.R
+++ b/R/revgeocode.R
@@ -20,6 +20,7 @@
 #' \url{http://code.google.com/apis/maps/documentation/geocoding/}
 #' @export
 #' @examples
+#' revgeocode(c(24, 64), urlonly = TRUE)
 #'
 #' \dontrun{ # Server response can be slow; this cuts down check time.
 #'

--- a/R/revgeocode.R
+++ b/R/revgeocode.R
@@ -22,7 +22,7 @@
 #' @examples
 #' revgeocode(c(24, 64), urlonly = TRUE)
 #'
-#' \dontrun{ # Server response can be slow; this cuts down check time.
+#' \donttest{ # Server response can be slow; this cuts down check time.
 #'
 #' ( gc <- as.numeric(geocode("the white house")) )
 #' revgeocode(gc)

--- a/R/route.R
+++ b/R/route.R
@@ -30,11 +30,12 @@
 #' \code{\link{register_google}}
 #' @export
 #' @examples
+#' from <- "houston, texas"
+#' to <- "waco, texas"
+#' route(from, to, urlonly = TRUE)
 #'
 #' \dontrun{ # to cut down on check time
 #'
-#' from <- "houston, texas"
-#' to <- "waco, texas"
 #' route_df <- route(from, to, structure = "route")
 #' trek_df  <-  trek(from, to, structure = "route")
 #' qmap("college station, texas", zoom = 8) +

--- a/R/route.R
+++ b/R/route.R
@@ -34,7 +34,7 @@
 #' to <- "waco, texas"
 #' route(from, to, urlonly = TRUE)
 #'
-#' \dontrun{ # to cut down on check time
+#' \donttest{ # to cut down on check time
 #'
 #' route_df <- route(from, to, structure = "route")
 #' trek_df  <-  trek(from, to, structure = "route")
@@ -254,7 +254,7 @@ check_route_query_limit <- function(url_string, elems, override, messaging){
 #' @seealso \url{https://developers.google.com/maps/documentation/directions/}
 #' @export
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' routeQueryCheck()
 #' }
 routeQueryCheck <- function(){
@@ -301,7 +301,7 @@ routeQueryCheck <- function(){
 #' @export
 #' @examples
 #'
-#' \dontrun{ # removed for R CMD check speed
+#' \donttest{ # removed for R CMD check speed
 #'
 #' map <- get_map(
 #'   location = c(-77.0425, 38.8925), # painfully picked by hand
@@ -414,7 +414,7 @@ geom_leg <- function(mapping = NULL, data = NULL, stat = "identity",
 #' @export
 #' @examples
 #'
-#' \dontrun{
+#' \donttest{
 #'
 #' (legs_df <- route("houston","galveston"))
 #' legs2route(legs_df)

--- a/R/theme_inset.R
+++ b/R/theme_inset.R
@@ -7,9 +7,8 @@
 #' @author David Kahle \email{david.kahle@@gmail.com}
 #' @export
 #' @examples
-#' library(ggplot2)
 #' \dontrun{
-#'
+#' library(ggplot2)
 #'
 #' n <- 50
 #' df <- expand.grid(x = 1:n,y = 1:n)[sample(n^2,.5*n^2),]

--- a/R/theme_inset.R
+++ b/R/theme_inset.R
@@ -7,7 +7,7 @@
 #' @author David Kahle \email{david.kahle@@gmail.com}
 #' @export
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(ggplot2)
 #'
 #' n <- 50

--- a/R/trek.R
+++ b/R/trek.R
@@ -31,11 +31,12 @@
 #' \code{\link{register_google}}
 #' @export
 #' @examples
+#' from <- "houston, texas"
+#' to <- "waco, texas"
+#' trek(from, to, urlonly = TRUE)
 #'
 #' \dontrun{ # to cut down on check time
 #'
-#' from <- "houston, texas"
-#' to <- "waco, texas"
 #' route_df <- route(from, to, structure = "route")
 #' trek_df <- trek(from, to, structure = "route")
 #' qmap("college station, texas", zoom = 8) +

--- a/R/trek.R
+++ b/R/trek.R
@@ -35,7 +35,7 @@
 #' to <- "waco, texas"
 #' trek(from, to, urlonly = TRUE)
 #'
-#' \dontrun{ # to cut down on check time
+#' \donttest{ # to cut down on check time
 #'
 #' route_df <- route(from, to, structure = "route")
 #' trek_df <- trek(from, to, structure = "route")

--- a/R/trek.R
+++ b/R/trek.R
@@ -50,9 +50,9 @@
 #'     size = 1.5, alpha = .5,
 #'     data = trek_df, lineend = "round"
 #'   )
+#' }
 #'
-#'
-#'
+#' \dontrun{
 #' from <- "rice university houston texas"
 #' to <- "1001 Bissonnet St, Houston, TX 77005"
 #' trek_df <- trek(from, to)
@@ -84,10 +84,6 @@
 #'   color = route, size = I(2), maptype = "terrain",
 #'   zoom = 5
 #' ) + facet_wrap(~ route, ncol = 1)
-#'
-#'
-#'
-#'
 #' }
 #'
 trek <- function(from, to, mode = c("driving","walking","bicycling", "transit"),

--- a/man/LonLat2XY.Rd
+++ b/man/LonLat2XY.Rd
@@ -26,8 +26,9 @@ zoom.  Decimal tile coordinates (x, y) are reported.
 }
 \examples{
 
+LonLat2XY(13, 60, 4)
 
-\dontrun{
+\donttest{
 gc <- geocode('baylor university')
 LonLat2XY(gc$lon, gc$lat, 10)
 

--- a/man/XY2LonLat.Rd
+++ b/man/XY2LonLat.Rd
@@ -30,14 +30,10 @@ zoom.  Decimal tile coordinates are accepted.
 }
 \examples{
 
-
-\dontrun{
 XY2LonLat(480, 845, zoom = 11)
 XY2LonLat(0, 0, zoom = 1)
 XY2LonLat(0, 0, 255, 255, zoom = 1)
 XY2LonLat(0, 0, 255, 255, zoom = 1)
-
-}
 
 }
 \author{

--- a/man/XY2LonLat.Rd
+++ b/man/XY2LonLat.Rd
@@ -33,7 +33,6 @@ zoom.  Decimal tile coordinates are accepted.
 XY2LonLat(480, 845, zoom = 11)
 XY2LonLat(0, 0, zoom = 1)
 XY2LonLat(0, 0, 255, 255, zoom = 1)
-XY2LonLat(0, 0, 255, 255, zoom = 1)
 
 }
 \author{

--- a/man/bb2bbox.Rd
+++ b/man/bb2bbox.Rd
@@ -22,7 +22,7 @@ functions (e.g. get_stamenmap).
 }
 \examples{
 
-\dontrun{# cut down on R CMD check time
+\donttest{# cut down on R CMD check time
 
 # grab a center/zoom map and compute its bounding box
 gc <- geocode("white house, washington dc")

--- a/man/file_drawer.Rd
+++ b/man/file_drawer.Rd
@@ -16,10 +16,10 @@ persist across sessions, set the global option
 }
 \examples{
 
-\dontrun{# if server is unresponsive, R check will fail
-
 file_drawer()
 dir(file_drawer())
+
+\donttest{# if server is unresponsive, R check will fail
 
 # The first time you run this, the tiles are downloaded from the server
 map <- get_stamenmap()

--- a/man/geocode.Rd
+++ b/man/geocode.Rd
@@ -60,17 +60,17 @@ Note that the Google Maps API limits to 2500 queries a day. Use
 }
 \examples{
 
-\dontrun{ # Server response can be slow; this cuts down check time.
-
 ##### basic usage
 ########################################
 
+geocode("ninos", inject = "region=es", urlonly = TRUE)
+
+\donttest{ # Server response can be slow; this cuts down check time.
 geocode("houston texas")
 geocode("1600 pennsylvania avenue, washington dc")
 geocode("the white house")
 geocode(c("the white house", "washington dc"))
 # see also mutate_geocode()
-geocode("ninos", inject = "region=es", urlonly = TRUE)
 
 
 ##### types of output
@@ -81,21 +81,21 @@ geocode("houston texas", output = "latlona")
 geocode("houston texas", output = "more")
 geocode("Baylor University", output = "more")
 str(geocode("Baylor University", output = "all"))
+}
 
-
+\dontrun{
 ##### interfacing with the google geocoding api
 ########################################
 
 register_google(key = "your code here")
 geocode("houston texas")
+}
 
-
+\donttest{
 # see how many requests we have left with google
 geocodeQueryCheck()
 geocode("one bear place, waco, texas")
 geocode("houston texas", force = TRUE)
-
-
 
 ##### known issues
 ########################################

--- a/man/geom_leg.Rd
+++ b/man/geom_leg.Rd
@@ -54,7 +54,7 @@ only intended for use in ggmap package.  only designed
 }
 \examples{
 
-\dontrun{ # removed for R CMD check speed
+\donttest{ # removed for R CMD check speed
 
 map <- get_map(
   location = c(-77.0425, 38.8925), # painfully picked by hand
@@ -121,7 +121,7 @@ ggplot(data = legs_df) +
 }
 
 
-\dontrun{ # removed for R CMD check speed
+\donttest{ # removed for R CMD check speed
 
 map <- get_map(
   location = c(-77.0425, 38.8925), # painfully picked by hand

--- a/man/get_googlemap.Rd
+++ b/man/get_googlemap.Rd
@@ -104,10 +104,9 @@ Service at \url{https://developers.google.com/maps/terms}.
 }
 \examples{
 
-\dontrun{ # to diminish run check time
-
-
 get_googlemap(urlonly = TRUE)
+
+\donttest{ # to diminish run check time
 ggmap(get_googlemap())
 
 
@@ -133,13 +132,16 @@ ggmap(get_googlemap(center = center, color = "bw", scale = 2), extent = "device"
 # (make your graphics device as large as possible)
 ggmap(get_googlemap(center, scale = 1), extent = "panel") # pixelated
 ggmap(get_googlemap(center, scale = 2), extent = "panel") # fine
+}
 
+\dontrun{
 # archiving; note that you must meet google's terms for this condition
 map <- get_googlemap(archiving = TRUE)
 map <- get_googlemap()
 ggmap(map)
+}
 
-
+\donttest{
 # style
 map <- get_googlemap(
   maptype = "roadmap",
@@ -147,10 +149,6 @@ map <- get_googlemap(
   color = "bw"
 )
 ggmap(map)
-
-
-
-
 }
 
 }

--- a/man/get_map.Rd
+++ b/man/get_map.Rd
@@ -70,12 +70,18 @@ map
 str(map)
 ggmap(map)
 
-\dontrun{
+\donttest{
 # not run by check to reduce time; also,
 # osm may error due to server overload
 
 (map <- get_map(maptype = "roadmap"))
+}
+
+\dontrun{
 (map <- get_map(source = "osm"))
+}
+
+\donttest{
 (map <- get_map(source = "stamen", maptype = "watercolor"))
 
 map <- get_map(location = "texas", zoom = 6, source = "stamen")

--- a/man/get_map.Rd
+++ b/man/get_map.Rd
@@ -85,7 +85,7 @@ ggmap(map)
 (map <- get_map(source = "stamen", maptype = "watercolor"))
 
 map <- get_map(location = "texas", zoom = 6, source = "stamen")
-ggmap(map, fullpage = TRUE)
+ggmap(map, extent = "device")
 
 }
 }

--- a/man/get_navermap.Rd
+++ b/man/get_navermap.Rd
@@ -72,7 +72,7 @@ Service at \url{http://dev.naver.com/openapi/apis/map/staticmap}.
 }
 \examples{
 
-\dontrun{
+\donttest{
 # not run to reduce R CMD check time
 
 map <- get_navermap(key="c75a09166a38196955adee04d3a51bf8", uri="www.r-project.org")

--- a/man/get_stamenmap.Rd
+++ b/man/get_stamenmap.Rd
@@ -51,8 +51,24 @@ Stamen maps don't cover the entire world, e.g.
 }
 \examples{
 
-\dontrun{ # to diminish run check time
+get_stamenmap(urlonly = TRUE)
 
+\donttest{
+# since mid-2016, stamen's terrain tileset is available for
+# the entire globe
+place <- "mount everest"
+(google <- get_googlemap(place, zoom = 9))
+ggmap(google)
+bbox_everest <- c(left = 86.05, bottom = 27.21, right = 87.81, top = 28.76)
+ggmap(get_stamenmap(bbox_everest, zoom = 9))
+
+# here's an interesting example:
+us <- c(left = -125, bottom = 25.75, right = -67, top = 49)
+map <- get_stamenmap(us, zoom = 5, maptype = "toner-labels")
+ggmap(map)
+}
+
+\dontrun{ # to diminish run check time
 
 ##### basic usage
 ########################################
@@ -70,16 +86,6 @@ ggmap(get_stamenmap(bbox, zoom = 14))
 ggmap(get_stamenmap(bbox, zoom = 15))
 # ggmap(get_stamenmap(bbox, zoom = 16))
 # ggmap(get_stamenmap(bbox, zoom = 17))
-
-
-
-# since mid-2016, stamen's terrain tileset is available for
-# the entire globe
-place <- "mount everest"
-(google <- get_googlemap(place, zoom = 9))
-ggmap(google)
-bbox_everest <- c(left = 86.05, bottom = 27.21, right = 87.81, top = 28.76)
-ggmap(get_stamenmap(bbox_everest, zoom = 9))
 
 
 # note that the osm code may not run due to overloaded
@@ -132,13 +138,6 @@ ggmap(get_stamenmap(bbox, zoom = 15, maptype = "watercolor"))+
 
 ggmap(get_stamenmap(bbox, zoom = 15, maptype = "toner"))+
   geom_point(aes(x = lon, y = lat), data = gc, colour = "red", size = 2)
-
-
-# here's an interesting example:
-us <- c(left = -125, bottom = 25.75, right = -67, top = 49)
-map <- get_stamenmap(us, zoom = 5, maptype = "toner-labels")
-ggmap(map)
-
 
 
 # accuracy check - white house

--- a/man/ggimage.Rd
+++ b/man/ggimage.Rd
@@ -31,7 +31,7 @@ ggimage(t(img[,4:1]), fullpage = FALSE, scale_axes = TRUE)
 ggimage(t(img[,4:1]), fullpage = FALSE)
 
 
-\dontrun{
+\donttest{
 # not run due to slow performance
 
 data(hadley)

--- a/man/ggmap.Rd
+++ b/man/ggmap.Rd
@@ -43,7 +43,7 @@ ggmap plots the raster object produced by \code{\link{get_map}}.
 }
 \examples{
 
-\dontrun{## map queries drag R CMD check
+\donttest{## map queries drag R CMD check
 
 
 ## extents and legends

--- a/man/legs2route.Rd
+++ b/man/legs2route.Rd
@@ -14,7 +14,7 @@ Convert a leg-structured route to a route-structured route
 }
 \examples{
 
-\dontrun{
+\donttest{
 
 (legs_df <- route("houston","galveston"))
 legs2route(legs_df)

--- a/man/mapdist.Rd
+++ b/man/mapdist.Rd
@@ -50,6 +50,7 @@ if parameters from and to are specified as geographic
   that the google maps api limits to 2500 element queries a day.
 }
 \examples{
+mapdist("waco, texas", "houston, texas", urlonly = TRUE)
 
 \dontrun{# online queries draw R CMD check times
 
@@ -60,13 +61,17 @@ to <- "waco, texas"
 mapdist(from, to)
 mapdist(from, to, mode = "bicycling")
 mapdist(from, to, mode = "walking")
+}
 
+\dontrun{
 # google requires a key for mode="transit"
 register_google(key = "[your key here]")
 from <- "city hall houston texas"
 to <- "nrg stadium houston texas"
 mapdist(from, to, mode = "transit")
+}
 
+\donttest{
 from <- c("houston", "houston", "dallas")
 to <- c("waco, texas", "san antonio", "houston")
 mapdist(from, to)

--- a/man/mutate_geocode.Rd
+++ b/man/mutate_geocode.Rd
@@ -23,13 +23,12 @@ information to the data frame provided.
 }
 \examples{
 
-
+\donttest{ # Server response can be slow; this cuts down check time.
 df <- data.frame(
   address = c("1600 Pennsylvania Avenue, Washington DC", "", "houston texas"),
   stringsAsFactors = FALSE
 )
 
-\dontrun{ # Server response can be slow; this cuts down check time.
 mutate_geocode(df, address)
 
 

--- a/man/qmap.Rd
+++ b/man/qmap.Rd
@@ -21,14 +21,20 @@ qmap is a wrapper for \code{\link{ggmap}} and
 }
 \examples{
 
-\dontrun{
+\donttest{
 # these examples have been excluded for checking efficiency
 
 location <- "marrs mclean science, waco, texas"
 qmap(location)
 qmap(location, zoom = 14)
+}
+
+\dontrun{
 qmap(location, zoom = 14, source = "osm")
 qmap(location, zoom = 14, source = "osm", scale = 20000)
+}
+
+\donttest{
 qmap(location, zoom = 14, maptype = "satellite")
 qmap(location, zoom = 14, maptype = "hybrid")
 qmap(location, zoom = 14, maptype = "toner", source = "stamen")

--- a/man/qmplot.Rd
+++ b/man/qmplot.Rd
@@ -80,7 +80,7 @@ data/models/etc.
 }
 \examples{
 
-\dontrun{ # these are skipped to conserve R check time
+\donttest{ # these are skipped to conserve R check time
 
 qmplot(lon, lat, data = crime)
 
@@ -293,7 +293,7 @@ qmplot(lon, lat, data = mg, shape = I(15), color = univKrige,
 
 
 
-} # end dontrun
+} # end donttest
 
 }
 

--- a/man/qmplot.Rd
+++ b/man/qmplot.Rd
@@ -152,9 +152,9 @@ qmplot(lon, lat, data = thinwind, geom = "tile", fill = spd, alpha = spd,
   scale_alpha("Wind Speed\\nand\\nDirection", range = c(.1, .75)) +
   guides(fill = guide_legend(), alpha = guide_legend())
 
+} # end donttest
 
-
-
+\dontrun{
 ## kriging
 ############################################################
 # the below examples show kriging based on undeclared packages
@@ -163,9 +163,7 @@ qmplot(lon, lat, data = thinwind, geom = "tile", fill = spd, alpha = spd,
 # they also require the rgdal library
 
 
-library(lattice)
-library(sp)
-library(rgdal)
+if (require("lattice") && require("sp") && require("rgdal")) {
 
 # load in and format the meuse dataset (see bivand, pebesma, and gomez-rubio)
 data(meuse)
@@ -194,10 +192,8 @@ qmplot(lon, lat, data = m, size = zinc,
 
 
 
-
-
+if (require("gstat")) { # still requiring lattice, sp and rgdal
 # load in the meuse.grid dataset (looking toward kriging)
-library(gstat)
 data(meuse.grid)
 coordinates(meuse.grid) <- c("x", "y")
 proj4string(meuse.grid) <- CRS("+init=epsg:28992")
@@ -287,13 +283,9 @@ qmplot(lon, lat, data = mg, shape = I(15), color = univKrige,
   ) +
   scale +
   scale_size("Observed\\nLog Zinc")
+}} # end two cases of if (require ...)
 
-
-
-
-
-
-} # end donttest
+} # end dontrun
 
 }
 

--- a/man/register_google.Rd
+++ b/man/register_google.Rd
@@ -69,7 +69,9 @@ has_goog_key()
 goog_key()
 has_goog_client()
 has_goog_signature()
+\dontrun{
 register_google(key = "[your key here]")
+}
 
 }
 \author{

--- a/man/revgeocode.Rd
+++ b/man/revgeocode.Rd
@@ -36,8 +36,9 @@ to the Google Maps API Terms of Service at
 https://developers.google.com/maps/terms.
 }
 \examples{
+revgeocode(c(24, 64), urlonly = TRUE)
 
-\dontrun{ # Server response can be slow; this cuts down check time.
+\donttest{ # Server response can be slow; this cuts down check time.
 
 ( gc <- as.numeric(geocode("the white house")) )
 revgeocode(gc)

--- a/man/route.Rd
+++ b/man/route.Rd
@@ -50,11 +50,12 @@ function you are agreeing to the Google Maps API Terms of Service
 at https://developers.google.com/maps/terms.
 }
 \examples{
-
-\dontrun{ # to cut down on check time
-
 from <- "houston, texas"
 to <- "waco, texas"
+route(from, to, urlonly = TRUE)
+
+\donttest{ # to cut down on check time
+
 route_df <- route(from, to, structure = "route")
 trek_df  <-  trek(from, to, structure = "route")
 qmap("college station, texas", zoom = 8) +

--- a/man/routeQueryCheck.Rd
+++ b/man/routeQueryCheck.Rd
@@ -13,7 +13,7 @@ a data frame
 Check Google Maps Directions API query limit
 }
 \examples{
-\dontrun{
+\donttest{
 routeQueryCheck()
 }
 }

--- a/man/theme_inset.Rd
+++ b/man/theme_inset.Rd
@@ -16,9 +16,8 @@ a ggplot2 theme (i.e., a list of class options).
 theme_inset is a ggplot2 theme geared towards making inset plots.
 }
 \examples{
+\donttest{
 library(ggplot2)
-\dontrun{
-
 
 n <- 50
 df <- expand.grid(x = 1:n,y = 1:n)[sample(n^2,.5*n^2),]

--- a/man/trek.Rd
+++ b/man/trek.Rd
@@ -48,11 +48,12 @@ Google Maps API Terms of Service at
 https://developers.google.com/maps/terms.
 }
 \examples{
-
-\dontrun{ # to cut down on check time
-
 from <- "houston, texas"
 to <- "waco, texas"
+trek(from, to, urlonly = TRUE)
+
+\donttest{ # to cut down on check time
+
 route_df <- route(from, to, structure = "route")
 trek_df <- trek(from, to, structure = "route")
 qmap("college station, texas", zoom = 8) +

--- a/man/trek.Rd
+++ b/man/trek.Rd
@@ -67,9 +67,9 @@ qmap("college station, texas", zoom = 8) +
     size = 1.5, alpha = .5,
     data = trek_df, lineend = "round"
   )
+}
 
-
-
+\dontrun{
 from <- "rice university houston texas"
 to <- "1001 Bissonnet St, Houston, TX 77005"
 trek_df <- trek(from, to)
@@ -101,10 +101,6 @@ qmplot(lon, lat, data = trek_df, geom = "path",
   color = route, size = I(2), maptype = "terrain",
   zoom = 5
 ) + facet_wrap(~ route, ncol = 1)
-
-
-
-
 }
 
 }


### PR DESCRIPTION
Now more examples can be run with just `example(funcname)` without an extra `run.dontrun=TRUE`, which was problematic anyway, as there was (and is) some unrunnable code inside `\dontrun`. The `\donttest` examples are not run by `R CMD check`, so there's no major increase to check times. My intention also was to keep all possibly problematic (terms of service etc.) examples in `\dontrun`.

Some more examples (some of which are new) are now outside `\dontrun` and `donttest`. All of these work without network access. This increases the code coverage of the tests run by `R CMD check`. It is also easy to run the `donttest` examples (no unrunnable code now) with `R CMD check --run-donttest`.

When adding a simple `urlonly=TRUE` example for `mapdist`, I discovered that the option was broken. A fix for that is included. This pull request also includes the changes made in #133.