### PR TITLE
Changed get_map zoom calculation to get min zoom level

### DIFF
--- a/R/get_map.R
+++ b/R/get_map.R
@@ -176,7 +176,7 @@ get_map <- function(
         latlength <- diff(lat_range)
         zoomlon <- ceiling( log2( 360*2 / lonlength) )
         zoomlat <- ceiling( log2( 180*2 / latlength) )
-        zoom <- max(zoomlon, zoomlat)
+        zoom <- min(zoomlon, zoomlat)
       }
     }
   } else if(zoom == "auto" && location_type != "bbox"){


### PR DESCRIPTION
Sometimes, if the bounding box is either very wide or very tall, the zoom level chosen in `get_map` is too high (i.e. too zoomed in).  I think the right behaviour is to choose the zoom level that captures the entire bounding box.