### PR TITLE
Fixing coord_map() replacement to work with ggplot2 dev version

### DIFF
--- a/R/coord_map.R
+++ b/R/coord_map.R
@@ -13,20 +13,29 @@ mproject2 <- function(coord, x, y, orientation){
 }
 
 # Modified ggplot2::coord_map, replaces uses of ggplot2:::mproject
-# with mproject2. Dependence on ggplot2 (version 2.2.0) internals is
+# with mproject2. Dependence on ggplot2 (version >= 2.2.0) internals is
 # unfortunate.
 coord_map2 <- function(){
   trans_fun <- get("f", environment(CoordMap$transform))
   trans_env <- new.env(parent = environment(trans_fun))
   assign("mproject", mproject2, trans_env)
   environment(trans_fun) <- trans_env
-  train_fun <- get("f", environment(CoordMap$train))
+  name_is_setup <- "setup_panel_params" %in% names(CoordMap)
+  if (name_is_setup) {
+      train_fun <- get("f", environment(CoordMap$setup_panel_params))
+  } else {
+      train_fun <- get("f", environment(CoordMap$train))
+  }
   train_env <- new.env(parent = environment(train_fun))
   assign("mproject", mproject2, train_env)
   environment(train_fun) <- train_env
-  ggproto(
-    NULL, CoordMap, projection = "mercator", orientation = NULL,
-    limits = list(x = NULL, y = NULL), params = list(),
-    transform = trans_fun, train = train_fun
-  )
+  ggargs <- alist(NULL, CoordMap, projection = "mercator", orientation = NULL,
+                  limits = list(x = NULL, y = NULL), params = list(),
+                  transform = trans_fun)
+  if (name_is_setup) {
+      ggargs <- c(ggargs, alist(setup_panel_params = train_fun))
+  } else {
+      ggargs <- c(ggargs, alist(train = train_fun))
+  }
+  do.call("ggproto", ggargs)
 }


### PR DESCRIPTION
Related to https://github.com/tidyverse/ggplot2/commit/165e4c9bcc102541d9a92de829ce4801b1772fcb. Should fix issue #144 (which should not occur with ggplot2 2.2.1 from CRAN).