### PR TITLE
geom_sf compatibility trick

### DIFF
--- a/R/ggmap.R
+++ b/R/ggmap.R
@@ -486,8 +486,8 @@ ggmap <- function(ggmap, extent = "panel", base_layer, maprange = FALSE,
       ymin <- attr(ggmap, "bb")$ll.lat
   	  ymax <- attr(ggmap, "bb")$ur.lat
 
-      p <- ggplot(aes(x = lon, y = lat), data = fourCorners) +
-  	    geom_blank() +
+      p <- ggplot(data = fourCorners) +
+  	    geom_blank(aes(x = lon, y = lat)) +
   	    inset_raster(ggmap, xmin, xmax, ymin, ymax) +
   	    annotate("rect", xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax,
   	      fill = darken[2], alpha = as.numeric(darken[1]))


### PR DESCRIPTION
Moving the x/y aesthetic seems to make ggmap compatible with the new geom_sf.

Note that the crs of the geom_sf should be set  to "+init=epsg:4326" in order to be compatible with the google map crs.

Example:
```
library(tidyverse)
library(sf)
library(ggmap)

data(meuse, package = "sp") # load data.frame from sp

meuse_sf = st_as_sf(meuse, coords = c("x", "y"), crs = 28992) %>%
  st_transform(crs = 4326)

meuse_bbox <- st_bbox(meuse_sf)

meuse_location <- c(lon = (meuse_bbox["xmin"]+meuse_bbox["xmax"])/2,
                 lat = (meuse_bbox["ymin"]+meuse_bbox["ymax"])/2)

meuse_map <- get_map(meuse_location, zoom = 13)

ggmap(meuse_map) + geom_sf(data = meuse_sf) +
  coord_sf(xlim = c(meuse_bbox["xmin"] - .1 * (meuse_bbox["xmax"]-meuse_bbox["xmin"]),
                    meuse_bbox["xmax"] + .1 * (meuse_bbox["xmax"]-meuse_bbox["xmin"])),
           ylim = c(meuse_bbox["ymin"] - .1 * (meuse_bbox["ymax"]-meuse_bbox["ymin"]),
                    meuse_bbox["ymax"] + .1 * (meuse_bbox["ymax"]-meuse_bbox["ymin"])))
```

yields

![rplot](https://user-images.githubusercontent.com/7868905/26935884-71a6073e-4c6d-11e7-8ee1-b557c8899978.png)

Note that I had to apply pull request https://github.com/dkahle/ggmap/pull/154 in order to make ggmap works with the github version of ggplot2.