### PR TITLE
Remove reference to OpenStreetMaps

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 
 # ggmap
 
-**ggmap** makes it easy to retrieve raster map tiles from popular online mapping services like [Google Maps](https://developers.google.com/maps/documentation/static-maps/?hl=en), [OpenStreetMap](https://www.openstreetmap.org), [Stamen Maps](http://maps.stamen.com), and plot them using the **ggplot2** framework:
+**ggmap** makes it easy to retrieve raster map tiles from popular online mapping services like [Google Maps](https://developers.google.com/maps/documentation/static-maps/?hl=en) and [Stamen Maps](http://maps.stamen.com) and plot them using the **ggplot2** framework:
 
 ```{r maptypes, message = FALSE}
 library(ggmap)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ggmap
 =====
 
-**ggmap** makes it easy to retrieve raster map tiles from popular online mapping services like [Google Maps](https://developers.google.com/maps/documentation/static-maps/?hl=en), [OpenStreetMap](https://www.openstreetmap.org), [Stamen Maps](http://maps.stamen.com), and plot them using the **ggplot2** framework:
+**ggmap** makes it easy to retrieve raster map tiles from popular online mapping services like [Google Maps](https://developers.google.com/maps/documentation/static-maps/?hl=en) and [Stamen Maps](http://maps.stamen.com) and plot them using the **ggplot2** framework:
 
 ``` r
 library(ggmap)


### PR DESCRIPTION
According to #117, OpenStreetMap isn’t supported anymore, leaving Google and Stamen as the main sources for tiles. Leaving a reference to OSM in the readme can lead people (like me) on long wild goose chases.