### PR TITLE
Use missing instead of evaling vararg environment members

### DIFF
--- a/R/ggmap.R
+++ b/R/ggmap.R
@@ -424,7 +424,7 @@
 #'
 #' }
 ggmap <- function(ggmap, extent = "panel", base_layer, maprange = FALSE,
-  legend = "right", padding = .02, darken = c(0, "black"), ...)
+  legend = "right", padding = .02, darken = c(0, "black"), b, fullpage, expand, ...)
 {
 
   # dummies to trick R CMD check
@@ -433,22 +433,16 @@ ggmap <- function(ggmap, extent = "panel", base_layer, maprange = FALSE,
   ll.lat <- NULL; rm(ll.lat); ur.lat <- NULL; rm(ur.lat);
 
   # deprecated syntaxes
-  args <- as.list(match.call(expand.dots = TRUE)[-1])
-  if("ggmapplot" %in% names(args)){
-    .Deprecated(msg = "ggmapplot syntax deprecated, use ggmap.")
-  }
-
-  if("b" %in% names(args)){
+  if(!missing(b)) {
     .Deprecated(msg = "b syntax deprecated, use padding.")
-    b <- NULL; rm(b);
-    padding <- eval(args$b)
+    padding <- b
   }
 
-  if("fullpage" %in% names(args) || "expand" %in% names(args)){
+  if(!missing(fullpage) || !missing(expand)){
     .Deprecated(msg = "fullpage and expand syntaxes deprecated, use extent.")
-    if("fullpage" %in% names(args)){fullpage <- eval(args$fullpage)}else{fullpage <- FALSE}
+    if(missing(fullpage)) { fullpage <- FALSE }
+    if(missing(expand)) { expand <- FALSE }
     if(fullpage) extent <- "device"
-    if("expand" %in% names(args)){expand <- eval(args$expand)}else{expand <- FALSE}
     if(fullpage == FALSE && expand == TRUE) extent <- "panel"
     if(fullpage == FALSE && expand == FALSE) extent <- "normal"
   }
@@ -603,6 +597,7 @@ ggmap <- function(ggmap, extent = "panel", base_layer, maprange = FALSE,
 ggmapplot <- function(ggmap, fullpage = FALSE,
   base_layer, maprange = FALSE, expand = FALSE, ...)
 {
+  .Deprecated(msg = "ggmapplot syntax deprecated, use ggmap.")
   ggmap(ggmap, fullpage = fullpage, base_layer = base_layer,
     maprange = FALSE, expand = FALSE, ggmapplot = TRUE)
 }

--- a/R/ggmap.R
+++ b/R/ggmap.R
@@ -17,6 +17,14 @@
 #'   is in [0, 1] and color is a character string indicating the
 #'   color of the darken.  0 indicates no darkening, 1 indicates a
 #'   black-out.
+#' @param b Deprecated, renamed to `padding`. Overrides any
+#'   `padding` argument.
+#' @param fullpage Deprecated, equivalent to `extent = "device"`
+#'   when `TRUE`. Overrides any `extent` argument.
+#' @param expand Deprecated, equivalent to `extent = "panel"`
+#'   when `TRUE` and `fullpage` is `FALSE`. When `fullpage`
+#'   is `FALSE` and `expand` is `FALSE`, equivalent to
+#'   `extent="normal"`. Overrides any `extent` argument.
 #' @param ... ...
 #' @return a ggplot object
 #' @author David Kahle \email{david.kahle@@gmail.com}

--- a/man/geom_leg.Rd
+++ b/man/geom_leg.Rd
@@ -31,12 +31,14 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+It can also be a named logical vector to finely select the aesthetics to
+display.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link{borders}}.}
+the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{...}{...}
 }

--- a/man/ggmap.Rd
+++ b/man/ggmap.Rd
@@ -9,7 +9,8 @@
 \title{Plot a ggmap object}
 \usage{
 ggmap(ggmap, extent = "panel", base_layer, maprange = FALSE,
-  legend = "right", padding = 0.02, darken = c(0, "black"), ...)
+  legend = "right", padding = 0.02, darken = c(0, "black"), b, fullpage,
+  expand, ...)
 }
 \arguments{
 \item{ggmap}{an object of class ggmap (from function get_map)}
@@ -33,6 +34,17 @@ with legend, formerly b)}
 is in [0, 1] and color is a character string indicating the
 color of the darken.  0 indicates no darkening, 1 indicates a
 black-out.}
+
+\item{b}{Deprecated, renamed to `padding`. Overrides any
+`padding` argument.}
+
+\item{fullpage}{Deprecated, equivalent to `extent = "device"`
+when `TRUE`. Overrides any `extent` argument.}
+
+\item{expand}{Deprecated, equivalent to `extent = "panel"`
+when `TRUE` and `fullpage` is `FALSE`. When `fullpage`
+is `FALSE` and `expand` is `FALSE`, equivalent to
+`extent="normal"`. Overrides any `extent` argument.}
 
 \item{...}{...}
 }

--- a/tests/testthat/test-ggmap.R
+++ b/tests/testthat/test-ggmap.R
@@ -2,13 +2,17 @@ context("ggmap")
 source("util.R")
 
 test_that("ggmap example works", {
-  skip("FIXME: Doesn't work with cran ggplot. When fixed, remove skip.")
   map <- getFakeMap()
   ggmap(map)
+  expect_true(TRUE) # didn't stop: good!
 })
 
 test_that("ggmapplot example works", {
-  skip("FIXME: Doesn't work with cran ggplot. When fixed, remove skip.")
   map <- getFakeMap()
-  ggmapplot(map)
+  expect_warning(
+    # deprecated, and uses deprecated syntax
+    # warns twice
+    ggmapplot(map)
+  )
+  expect_true(TRUE) # didn't stop: good!
 })


### PR DESCRIPTION
I tried out #154 locally, merged with my #182 to iterate on some tests. `ggmapplot()` was failing due to the interesting vararg tricks happening in `ggmap`.

I replaced this trick with the old `missing` function. If the deprecated args aren't missing, we throw a deprecation warning. If the deprecated args are missing, then we go about our merry way.

When I merged all three together, my tests pass with newest ggplot2.