### PR TITLE
Added override limit clause to an error catch

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -114,7 +114,7 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
 
     # message/stop as neeeded
     s <- sprintf("google restricts requests to %s requests a day for non-premium use.", limit)
-    if(length(location) > as.numeric(limit)) stop(s, call. = FALSE)
+    if(length(location) > as.numeric(limit) && !override_limit) stop(s, call. = FALSE)
     if(length(location) > 200 && messaging) message(paste("Reminder", s, sep = " : "))
 
     # geocode ply and out


### PR DESCRIPTION
Right now there is an override limit argument. But even with that toggled to TRUE, you still catch a limit error on a standard account. If you have a standard account linked to billing, the query limit is no problem, so your query should be allowed to proceed. Hope that helps.