### PR TITLE
Updated max URL Length

### DIFF
--- a/R/get_googlemap.R
+++ b/R/get_googlemap.R
@@ -329,7 +329,7 @@ get_googlemap <- function(
 
   url <- URLencode( enc2utf8(url) )
   if(urlonly) return(url)
-  if(nchar(url) > 2048) stop("max url length is 2048 characters.", call. = FALSE)
+  if(nchar(url) > 8192) stop("max url length is 8192 characters.", call. = FALSE)
 
 
   ##### get map


### PR DESCRIPTION
The max length of google map URLs has been increased from 2048 to 8192: https://developers.google.com/maps/documentation/static-maps/intro

> "Google Static Maps API URLs are restricted to 8192 characters in size. In practice, you will probably not have need for URLs longer than this, unless you produce complicated maps with a high number of markers and paths. Note, however, that certain characters may be URL-encoded by browsers and/or services before sending them off to the API, resulting in increased character usage. For more information, see Building a Valid URL."

I have updated the code to reflect this change. This was rarely a problem within ggmap, as URLs are shorter. The only time I have encountered a problem with the URL is when doing advance styling with lots of changes.

I checked the package as requested before making the suggestion.

Thanks for the great package 👍 
