### PR TITLE
Fix geocode() rate error for source = dsk

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,8 @@ FIXES
 * README images moved from figures/ to tools/
 * mutate_geocode() now works with tibbles (#68, thanks dannguyen)
 * get_stamenmap() now properly changes colors to black and white.
+* geocode() now stops with a rate limiter error only when source = 'google'
+  (#150, thanks @phively)
 
 
 ggmap 2.6.1

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -114,8 +114,8 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
 
     # message/stop as neeeded
     s <- sprintf("google restricts requests to %s requests a day for non-premium use.", limit)
-    if(length(location) > as.numeric(limit)) stop(s, call. = FALSE)
-    if(length(location) > 200 && messaging) message(paste("Reminder", s, sep = " : "))
+    if(length(location) > as.numeric(limit) && source == "google") stop(s, call. = FALSE)
+    if(length(location) > 200 && messaging && source == "google") message(paste("Reminder", s, sep = " : "))
 
     # geocode ply and out
     if(output == "latlon" || output == "latlona" || output == "more"){


### PR DESCRIPTION
This is a 2-line fix for issue #150 allowing address vectors with more than 2500 elements to be geocoded with source = 'dsk'. I ran devtools::check() and roxygen2::roxygenise(".") without any problems.

This method is different from the one in pull request #156 which appears to introduce a bug when the [if statement on line 120](https://github.com/dkahle/ggmap/pull/156/commits/d558e7efe11228029bccc2b83ccf1059b8a57590) is evaluated (if source != 'google' then string s would not exist).

Thanks for the fantastic package!