### PR TITLE
Test that printing works, fix getFakeMap()

### DIFF
--- a/tests/testthat/test-ggmap.R
+++ b/tests/testthat/test-ggmap.R
@@ -3,7 +3,7 @@ source("util.R")
 
 test_that("ggmap example works", {
   map <- getFakeMap()
-  ggmap(map)
+  print(ggmap(map))
   expect_true(TRUE) # didn't stop: good!
 })
 
@@ -12,7 +12,7 @@ test_that("ggmapplot example works", {
   expect_warning(
     # deprecated, and uses deprecated syntax
     # warns twice
-    ggmapplot(map)
+    print(ggmapplot(map))
   )
   expect_true(TRUE) # didn't stop: good!
 })

--- a/tests/testthat/util.R
+++ b/tests/testthat/util.R
@@ -1,5 +1,5 @@
 getFakeMap <- function() {
-  map <- character()
+  map <- matrix("#000000")
   class(map) <- c('ggmap','raster')
   attr(map, "source")  <- "osm"
   attr(map, "maptype") <- "openstreetmap"


### PR DESCRIPTION
The `ggmap()` and `ggmapplot()` tests should probably check that printing the object works. The patch implements this. Also `getFakeMap()` was fixed so that the examples (with printing) do work.

## Before you open your PR

- [x] Did you run R CMD CHECK?
- [x] Did you run `roxygen2::roxygenise(".")`?

Thanks for contributing!

