### PR TITLE
Modify return of failedGeocodeReturn() function

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -441,12 +441,12 @@ failedGeocodeReturn <- function(output){
   } else if(output == "latlona"){
     return(c(lon = NA_real_, lat = NA_real_, address = NA_character_))
   } else if(output == "more") {
-    return(c(
+    return(data.frame(list(
       lon = NA_real_, lat = NA_real_, type = NA_character_, loctype = NA_character_,
       address = NA_character_,
       north = NA_real_, south = NA_real_, east = NA_real_, west = NA_real_,
       locality = NA_character_, country = NA_character_
-    ))
+    )))
   } else {
     return(NA_real_)
   }


### PR DESCRIPTION
`failedGeocodeReturn` function returns a named vector, this will cause problem in the line 121 of `ldply` function to combine named vector and data.frame together, i.e. try running code `geocode(c("CASIRATE  D\u0092ADDA Italy","Shanghai"),output = "more")`
Transform the named vector to a data.frame will resolve the problem

## Before you open your PR

- [x] Did you run R CMD CHECK?
- [x] Did you run `roxygen2::roxygenise(".")`?

Thanks for contributing!

