### PR TITLE
Failed map requests give an error and stop #262

### DIFF
--- a/R/get_googlemap.R
+++ b/R/get_googlemap.R
@@ -370,7 +370,7 @@ get_googlemap <- function(
 
   # deal with bad responses
   if (response$status_code != 200L) {
-    warning(
+    stop(
       tryCatch(stop_for_status(response),
         "http_400" = function(c) "HTTP 400 Bad Request",
         "http_402" = function(c) "HTTP 402 Payment Required - May indicate over Google query limit",
@@ -379,8 +379,8 @@ get_googlemap <- function(
         "http_414" = function(c) "HTTP 414 URI Too Long - URL query too long",
         "http_500" = function(c) "HTTP 500 Internal Server Error",
         "http_503" = function(c) "HTTP 503 Service Unavailable - Server bogged down, try later"
-      )
-    )
+      ),
+      '\n', httr::content(response))
   }
 
 


### PR DESCRIPTION
## Before you open your PR

- [ x] Did you run R CMD CHECK?
- [ x] Did you run `roxygen2::roxygenise(".")`?

This fixes #262 by giving an error with a helpful message when the map API request fails. Previously the failure only triggered a warning and subsequent code gave obscure errors because the response data was not as expected.

