### PR TITLE
Updated get_stadiamap.R watercolor name to match new maptype name, stamen_watercolor

### DIFF
--- a/R/get_stadiamap.R
+++ b/R/get_stadiamap.R
@@ -303,7 +303,7 @@ get_stamen_url <- function(maptype, zoom, x, y) {
   key <- stadiamaps_key()
 
   # format URL
-  if(maptype %in% c("watercolor")) filetype <- "jpg" else filetype <- "png"
+  if(maptype %in% c("stamen_watercolor")) filetype <- "jpg" else filetype <- "png"
   url <- glue("https://tiles.stadiamaps.com/tiles/{maptype}/{zoom}/{x}/{y}.{filetype}?api_key={key}")
 
   return(url)


### PR DESCRIPTION
## Before you open your PR

- [x] Did you run R CMD CHECK?
- [x] Did you run `roxygen2::roxygenise(".")`?

## Description

Since the last update to address the hosting changes for Stamen tiles to Stadia Maps, the Stamen Water color style's maptype was changed from `watercolor` to `stamen_watercolor` in `get_stadiamap.R`.  

When the filetype check occurs (line 306), the old name, `watercolor`, is still referenced.  This pull request updates the name to `stamen_watercolor`.

Closes #356

