### PR TITLE
Change max to min in calc_zoom.r

### DIFF
--- a/R/calc_zoom.r
+++ b/R/calc_zoom.r
@@ -67,7 +67,7 @@ calc_zoom <- function(lon, lat, data, adjust = 0, f = .05){
   latlength <- diff(lat_range)
   zoomlon <- ceiling(log2(360 * 2/lonlength))
   zoomlat <- ceiling(log2(180 * 2/latlength))
-  zoom <- max(zoomlon, zoomlat)
+  zoom <- min(zoomlon, zoomlat)
 
   zoom + adjust
 }


### PR DESCRIPTION
When using max zoom the map from google frequently does not encompass all coordinates to plot. Better to use min (the smallest zoom calculated from lat and lon)

## Before you open your PR

- [ ] Did you run R CMD CHECK?
- [ ] Did you run `roxygen2::roxygenise(".")`?

Thanks for contributing!

